### PR TITLE
Fix for multiple db's

### DIFF
--- a/configs/tiab-entrypoint-configmap.j2
+++ b/configs/tiab-entrypoint-configmap.j2
@@ -22,12 +22,28 @@ data:
       rm -rf /iri/data/spamnet*
       rm -rf /iri/data/testnet*
       rm -rf /iri/data/mainnet*
-      ARCHIVE_SUBPATH=$(tar tfv /tmp/db.tar | grep -F 'db/' | grep -E '^d'  | awk '{print $6}')
-      STRIP_COMPONENTS=$(echo $ARCHIVE_SUBPATH | awk -F'/' '{print NF-2}')
-      tar xfv /tmp/db.tar --strip-components=$STRIP_COMPONENTS -C /iri/data $ARCHIVE_SUBPATH
-      SNAPSHOT_ARCHIVE_SUBPATH=$(tar tfv /tmp/db.tar | grep -F 'snapshot.txt' | awk '{print $6}')
+
+      ADDRESSES_ARCHIVE_SUBPATH=$(tar tfv /tmp/db.tar | grep -F 'spent-addresses-db/' | grep -E '^d'  | awk '{print $6}')
+      STRIP_COMPONENTS=$(echo $ADDRESSES_ARCHIVE_SUBPATH | awk -F '/' '{print NF-2}')
+      tar xfv /tmp/db.tar --strip-components=$STRIP_COMPONENTS -C /iri/data $ADDRESSES_ARCHIVE_SUBPATH
+
+      SPAMNET_ARCHIVE_SUBPATH=$(tar tfv /tmp/db.tar | grep -F 'spamnetdb/' | grep -E '^d'  | awk '{print $6}')
+      STRIP_COMPONENTS=$(echo $SPAMNET_ARCHIVE_SUBPATH | awk -F '/' '{print NF-2}')
+      tar xfv /tmp/db.tar --strip-components=$STRIP_COMPONENTS -C /iri/data $SPAMNET_ARCHIVE_SUBPATH
+
+      TESTNET_ARCHIVE_SUBPATH=$(tar tfv /tmp/db.tar | grep -F 'testnetdb/' | grep -E '^d'  | awk '{print $6}')
+      STRIP_COMPONENTS=$(echo $TESTNET_ARCHIVE_SUBPATH | awk -F '/' '{print NF-2}')
+      tar xfv /tmp/db.tar --strip-components=$STRIP_COMPONENTS -C /iri/data $TESTNET_ARCHIVE_SUBPATH
+
+      MAINNET_ARCHIVE_SUBPATH=$(tar tfv /tmp/db.tar | grep -F 'mainnetdb/' | grep -E '^d'  | awk '{print $6}')
+      STRIP_COMPONENTS=$(echo $MAINNET_ARCHIVE_SUBPATH | awk -F '/' '{print NF-2}')
+      tar xfv /tmp/db.tar --strip-components=$STRIP_COMPONENTS -C /iri/data $MAINNET_ARCHIVE_SUBPATH
+
+      SNAPSHOT_ARCHIVE_SUBPATH=$(tar tfv /tmp/db.tar | grep -F 'snapshot.' | awk '{print $6}')
       SNAPSHOT_STRIP_COMPONENTS=$(echo $SNAPSHOT_ARCHIVE_SUBPATH | awk -F'/' '{print NF-1}')
       tar xfv /tmp/db.tar --strip-components=$SNAPSHOT_STRIP_COMPONENTS -C /iri/data $SNAPSHOT_ARCHIVE_SUBPATH
+
     fi
 
     /entrypoint.sh "$@"
+


### PR DESCRIPTION
Added a quick fix to allow various DB's to be added in one tar file for the clusters. This is necessary now that there has been the addition of snapshot files.  

**Note: There's likely a more encompassing line that can be used, but as a quick fix this allows the `ciglue.sh` and `create_cluster.py` files to run without error.  