### PR TITLE
Modified entrypoint.sh call + delayed container shutdown

### DIFF
--- a/configs/tiab-entrypoint-configmap.j2
+++ b/configs/tiab-entrypoint-configmap.j2
@@ -62,5 +62,6 @@ data:
 
     {{ EXTRAS_COMMANDS_PLACEHOLDER }}
 
-    /entrypoint.sh "$@"
+    /bin/bash -l -c '/entrypoint.sh "$@"'
 
+    sleep 30


### PR DESCRIPTION
As per PR title. Added to delay the shutdown of TIAB instances after killing the java process.