### PR TITLE
NET_ADMIN IRI container capability & allow extra commands from cluster configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ $ pip install -r requirements.txt
 -k / --kubeconfig         Path of the kubectl config file to access the K8S cluster
 -n / --namespace          Kubernetes namespace you want to deploy the cluster to
 -x / --ixis               Base path for IXI modules to be specified in cluster configuration, defaults to CWD
+-e / --extras             Additional commands to be run at pod creation
 -d / --debug              print debug information
 ```
 
@@ -76,8 +77,14 @@ You can easily destroy all the resources associated to the cluster you just crea
 $ ./teardown_cluster.py --tag 1.5.3-deployment
 ```
 
+## Extra commands at Cluster startup
+
+If you need to execute a bunch of extra commands before each node starts you can run `create_cluster.py` with the `-e|--extras` command line or define an `extra_commands:` entry in the top level of the cluster definition yaml file.
+Please note that these two ways of specifying commands are not mutually exclusive: they are instead additive, both commands will be executed, one after the other.
+Also please note that the specified commands will be executed in bash context: so you can use any sort of bash magic you want (`>`, `&`, and alike).
+
 ## Monitoring capabilities (Alpha)
 
-If the `config.yml` file includes a `monitoring: True` entry, a twin [tanglescope](https://github.com/iotaledger/entangled) pod will be deployed along every IRI node. Tanglescope wil be responsible to obtain any sort of metrics on the node and serve them to a central Grafana Pod, using Prometheus as a database backend.
+If the `config.yml` file includes a `monitoring: True` entry at top level, a twin [tanglescope](https://github.com/iotaledger/entangled) pod will be deployed along every IRI node. Tanglescope wil be responsible to obtain any sort of metrics on the node and serve them to a central Grafana Pod, using Prometheus as a database backend.
 
 

--- a/configs/iri-pod.j2
+++ b/configs/iri-pod.j2
@@ -61,6 +61,10 @@ spec:
         - containerPort: 5556
         # JProfiler
         - containerPort: 8849
+      securityContext:
+        capabilities:
+          add:
+            - NET_ADMIN
   volumes:
     - name: tiab-entrypoint
       configMap:

--- a/configs/tiab-entrypoint-configmap.j2
+++ b/configs/tiab-entrypoint-configmap.j2
@@ -61,6 +61,7 @@ data:
     fi
 
     {{ EXTRAS_COMMANDS_PLACEHOLDER }}
+    {{ CONFIG_EXTRAS_COMMANDS_PLACEHOLDER }}
 
     /bin/bash -l -c '/entrypoint.sh "$@"'
 

--- a/create_cluster.py
+++ b/create_cluster.py
@@ -255,6 +255,7 @@ output = None
 ixis_path = os.getcwd()
 healthy = True
 extras_cmd = None
+config_extras_cmd = None
 
 if __name__ == '__main__':
     try:
@@ -288,7 +289,8 @@ if __name__ == '__main__':
 
     tiab_entrypoint_configmap_resource = yaml.load(tiab_entrypoint_configmap_template.render(
         TAG_PLACEHOLDER = tag,
-        EXTRAS_COMMANDS_PLACEHOLDER = extras_cmd if extras_cmd else ''
+        EXTRAS_COMMANDS_PLACEHOLDER = extras_cmd if extras_cmd else '',
+        CONFIG_EXTRAS_COMMANDS_PLACEHOLDER = cluster['extra_commands'] if cluster['extra_commands'] else ''
     ))
 
     try:


### PR DESCRIPTION
* Add the NET_ADMIN capability to the container hosting the IRI node, this would allow the container to alter its routing table and iptables rules for simulating certain network conditions or problems.
* Extra commands to be executed before node startup can now be defined within the YAML cluster configuration file itself in addition to the `create_cluster.py` command line with the `-e|--extras` flag.

Fixes #13 