### PR TITLE
Grep for directory

### DIFF
--- a/configs/tiab-entrypoint-configmap.j2
+++ b/configs/tiab-entrypoint-configmap.j2
@@ -44,7 +44,7 @@ data:
       SNAPSHOT_STRIP_COMPONENTS=$(echo $SNAPSHOT_ARCHIVE_SUBPATH | awk -F'/' '{print NF-1}')
       tar xfv /tmp/db.tar --strip-components=$SNAPSHOT_STRIP_COMPONENTS -C /iri/data $SNAPSHOT_ARCHIVE_SUBPATH
 
-      LOCAL_SNAPSHOTS_ARCHIVE_SUBPATH=$(tar tfv /tmp/db.tar | grep -F 'localsnapshots' | awk '{print $6}')   
+      LOCAL_SNAPSHOTS_ARCHIVE_SUBPATH=$(tar tfv /tmp/db.tar | grep -F 'localsnapshots-db'| grep -E '^d' | awk '{print $6}')   
       STRIP_COMPONENTS=$(echo $LOCAL_SNAPSHOTS_ARCHIVE_SUBPATH | awk -F '/' '{print NF-2}')
       tar xfv /tmp/db.tar --strip-components=$STRIP_COMPONENTS -C /iri/data $LOCAL_SNAPSHOTS_ARCHIVE_SUBPATH
 


### PR DESCRIPTION
Forgot to throw in the `grep -E '^d'`. It tries to unpack the files individually instead. 